### PR TITLE
Update launch.sh

### DIFF
--- a/rootfs/usr/local/bin/launch.sh
+++ b/rootfs/usr/local/bin/launch.sh
@@ -73,8 +73,8 @@ fi
 
 if [ "$PHP82" = "true" ]; then PHP_INI_SCAN_DIR=/data/php/82/conf.d php-fpm82 -c /data/php/82 -y /data/php/82/php-fpm.conf -FOR; fi &
 if [ "$PHP83" = "true" ]; then PHP_INI_SCAN_DIR=/data/php/83/conf.d php-fpm83 -c /data/php/83 -y /data/php/83/php-fpm.conf -FOR; fi &
-if [ "$LOGROTATE" = "true" ] && [ "$GOA" = "false" ]; then sleep 1m; while true; do logrotate --verbose --state /data/etc/logrotate.status /etc/logrotate; sleep 25h; done; fi &
-if [ "$LOGROTATE" = "true" ] && [ "$GOA" = "true" ]; then sleep 1m; while true; do killall goaccess; sleep 10s; logrotate --verbose --state /data/etc/logrotate.status /etc/logrotate; sleep 25h; done; fi &
+if [ "$LOGROTATE" = "true" ] && [ "$GOA" = "false" ]; then while true; do sleep 25h; logrotate --verbose --state /data/etc/logrotate.status /etc/logrotate; done; fi &
+if [ "$LOGROTATE" = "true" ] && [ "$GOA" = "true" ]; then while true; do sleep 25h; killall goaccess; sleep 10s; logrotate --verbose --state /data/etc/logrotate.status /etc/logrotate; done; fi &
 # shellcheck disable=SC2086
 if [ "$GOA" = "true" ]; then while true; do goaccess --no-global-config --num-tests=0 --tz="$TZ" --date-format="%d/%b/%Y" --time-format="%H:%M:%S" --log-format='[%d:%t %^] %v %h %T "%r" %s %b %b %R %u' --no-ip-validation --addr=127.0.0.1 --port="$GOAIWSP" \
                                 -f /data/nginx/access.log --real-time-html -o /tmp/goa/index.html --persist --restore --db-path=/data/etc/goaccess/data -b /etc/goaccess/browsers.list -b /etc/goaccess/podcast.list $GOACLA; done; fi &


### PR DESCRIPTION
move sleep in log rotate lines to start so it waits 25hrs before its first rotate. (NB this is best for a live environment that isn't being restarted regularly like the dev environments)

sorry for not responding to your previous comment. I'll look at the other place to do the goaccess kill but I don't think it'll work as smoothly.